### PR TITLE
Update to work with Markdown-it 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "markdown-it-toc",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "description": "Adds syntax for an automatically generated table of contents to markdown-it markdown parser.",
     "main": "index.js",
     "scripts": {
@@ -22,7 +22,7 @@
     },
     "homepage": "https://github.com/samchrisinger/markdown-it-toc",
     "devDependencies": {
-	 "markdown-it": "^3.0.4",
+	 "markdown-it": "^4.1.0",
 	"markdown-it-testgen": "^0.1.4",
 	"coveralls": "^2.11.2",
 	"eslint": "^0.13.0",

--- a/test/fixtures/toc.txt
+++ b/test/fixtures/toc.txt
@@ -39,6 +39,34 @@ Some content
 
 Test4
 .
+@[toc]
+
+Heading 1
+=====
+
+Some Content
+
+SubHeading
+-----
+
+Some content
+
+Heading 2
+=====
+
+### Deeper Heading
+.
+<p><h3>Table of Contents</h3><ul><li><a href="#Heading_1_2">Heading 1</a></li><ul><li><a href="#SubHeading_7">SubHeading</a></li></ul><li><a href="#Heading_2_12">Heading 2</a></li><ul><ul><li><a href="#Deeper_Heading_15">Deeper Heading</a></li></ul></ul></ul></p>
+<h1><a id="Heading_1_2"></a>Heading 1</h1>
+<p>Some Content</p>
+<h2><a id="SubHeading_7"></a>SubHeading</h2>
+<p>Some content</p>
+<h1><a id="Heading_2_12"></a>Heading 2</h1>
+<h3><a id="Deeper_Heading_15"></a>Deeper Heading</h3>
+.
+
+Test5
+.
 @[toc](Title)
 
 # Heading 1


### PR DESCRIPTION
Markdown-it updated to 4.1. Fix many of the things the
update broke.

Add tests to deal with == and -- alternate headlines.

Bump version to 1.1.0.

There is a difference in the new syntax that was not compatible when 4.1 was used. It looks like I got most of that. Not sure on a couple lines but it also passed all tests so not sure how that will go.