### PR TITLE
Added tocHeader option to be set as option

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function(md) {
         token.markup = '@[toc]';
 
         token = state.push('toc_body', '', 0);
-        var label = TOC_DEFAULT;
+        var label = state.env.tocHeader || TOC_DEFAULT;
         if (match.length > 1) {
             label = match.pop();
         }

--- a/test/test.js
+++ b/test/test.js
@@ -2,12 +2,18 @@
 
 var path = require('path');
 var generate = require('markdown-it-testgen');
+var md = require('markdown-it')({
+html: true,
+linkify: true,
+typography: true
+}).use(require('../'));
 
 describe('markdown-it-toc', function() {
-  var md = require('markdown-it')({
-    html: true,
-    linkify: true,
-    typography: true
-  }).use(require('../'));
   generate(path.join(__dirname, 'fixtures/toc.txt'), md);
+});
+
+describe('markdown-it-toc-default', function() {
+  generate(path.join(__dirname, 'fixtures/toc2.txt'), {
+  	tocHeader: "test"
+  }, md);
 });


### PR DESCRIPTION
I just had the case where I want to offer a @toc method that has a different header depending on the language of the file I output. It was not possible without introducing a way to override the default.